### PR TITLE
Switch Docker base image for reduced image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.9-slim
 
 ADD Vaccinbot.py ./
 ADD requirements.txt .


### PR DESCRIPTION
Hi, thanks for putting this together! There might be good reasons for using the current base image, so of course feel free to close this. If size is a concern, the switch to the [`slim` image version](https://github.com/docker-library/docs/tree/master/python#pythonversion-slim) reduces the final size of the Docker image from 903 MB to 132 MB.