### PR TITLE
Add support for the Free Mobile API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,39 +6,38 @@ By default it finds appointments for all vaccine types within 50km from St. Geni
 Use:
 
 ```
-usage: Vaccinbot.py [-h] [--interval INTERVAL] [--slack-token SLACK_TOKEN]
-                    [--location LAT LONG] [--max-distance MAX_DISTANCE]
-                    [--vaccines [VACCINES [VACCINES ...]]]
-                    [--depts [DEPTS [DEPTS ...]]]
+usage: Vaccinbot.py [-h] [--interval INTERVAL] [--slack-token SLACK_TOKEN] [--free-mobile-user FREE_MOBILE_USER] [--free-mobile-pass FREE_MOBILE_PASS] [--location LAT LONG]
+                    [--max-distance MAX_DISTANCE] [--vaccines [VACCINES ...]] [--depts [DEPTS ...]]
 
-A bot that automatically fetches date from ViteMaDose and finds appointments
-within 24h.
+A bot that automatically fetches date from ViteMaDose and finds appointments within 24h.
 
 optional arguments:
   -h, --help            show this help message and exit
-  --interval INTERVAL   Time in minutes between queries to ViteMaDose.
-                        Default: 15
+  --interval INTERVAL   Time in minutes between queries to ViteMaDose. Default: 15
   --slack-token SLACK_TOKEN
                         Path to file containing a slack token (activates Slack bot feature).
+  --free-mobile-user FREE_MOBILE_USER
+                        User to be used with the Free Mobile SMS API
+  --free-mobile-pass FREE_MOBILE_PASS
+                        Password used for the Free Mobile SMS API
   --location LAT LONG   Latitude and longitude of your location. Default: St. Genis.
   --max-distance MAX_DISTANCE
-                        Maximum radius of search from your position in km. 
-                        Default: 50 km
-  --vaccines [VACCINES [VACCINES ...]]
-                        List of vaccines to look for. P=Pfizer-BioNTech; M=Moderna; AZ=AstraZeneca; J=Janssen; mRNA. Default: all.
-  --depts [DEPTS [DEPTS ...]]
-                        List of department numbers where to look for vaccines
-                        (add 0 before single-digit depts. e.g. 01 not 1).
-                        Default: 01 (Ain) + neighbouring depts.
+                        Maximum radius of search from your position in km. Default: 50 km
+  --vaccines [VACCINES ...]
+                        List of vaccines to look for. P=Pfizer-BioNTech; M=Moderna; AZ=AstraZeneca; J=Janssen. Default: all.
+  --depts [DEPTS ...]   List of department numbers where to look for vaccines (add 0 before single-digit depts. e.g. 01 not 1). Default: 01 (Ain) + neighbouring depts.
 ```
 
 Example:
 
-No Slack bot:
+* Text only:
 ```./Vaccinbot.py --interval 20 --location 46 6 --max-distance 55 --vaccines P  ```
 
-With Slack bot:
+* Slack bot:
 ```python3.6 Vaccinbot.py --interval 20 --slack-token slack_token.txt --location 46 6 --max-distance 55 --vaccines AZ J ```
+
+* Free Mobile API:
+```python3.6 Vaccinbot.py --free_mobile_user user --free_mobile_pass pass```
 
 ## Dependencies
 The dependencies can be installed from the command line via `pip`:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ By default it finds appointments for all vaccine types within 50km from St. Geni
 Use:
 
 ```
-usage: Vaccinbot.py [-h] [--interval INTERVAL] [--slack-token SLACK_TOKEN] [--free-mobile-user FREE_MOBILE_USER] [--free-mobile-pass FREE_MOBILE_PASS] [--location LAT LONG]
-                    [--max-distance MAX_DISTANCE] [--vaccines [VACCINES ...]] [--depts [DEPTS ...]]
+usage: Vaccinbot.py [-h] [--interval INTERVAL] [--slack-token SLACK_TOKEN] [--free-mobile-user FREE_MOBILE_USER] [--location LAT LONG] [--max-distance MAX_DISTANCE]
+                    [--vaccines [VACCINES ...]] [--depts [DEPTS ...]]
 
 A bot that automatically fetches date from ViteMaDose and finds appointments within 24h.
 
@@ -18,8 +18,6 @@ optional arguments:
                         Path to file containing a slack token (activates Slack bot feature).
   --free-mobile-user FREE_MOBILE_USER
                         User to be used with the Free Mobile SMS API
-  --free-mobile-pass FREE_MOBILE_PASS
-                        Password used for the Free Mobile SMS API
   --location LAT LONG   Latitude and longitude of your location. Default: St. Genis.
   --max-distance MAX_DISTANCE
                         Maximum radius of search from your position in km. Default: 50 km
@@ -37,7 +35,7 @@ Example:
 ```python3.6 Vaccinbot.py --interval 20 --slack-token slack_token.txt --location 46 6 --max-distance 55 --vaccines AZ J ```
 
 * Free Mobile API:
-```python3.6 Vaccinbot.py --free_mobile_user user --free_mobile_pass pass```
+```python3.6 Vaccinbot.py --free_mobile_user user```
 
 ## Dependencies
 The dependencies can be installed from the command line via `pip`:

--- a/Vaccinbot.py
+++ b/Vaccinbot.py
@@ -32,16 +32,28 @@ SELECTED_VACCINES = ["P", "M", "AZ", "J", "mRNA"]
 
 
 # Argument parsing
+def get_args():
+    parser = argparse.ArgumentParser(description="A bot that automatically fetches date from ViteMaDose and finds appointments within 24h.")
+    parser.add_argument("--interval", type=int, help="Time in minutes between queries to ViteMaDose. Default: " + str(PING_INTERVAL_MINUTES), default=PING_INTERVAL_MINUTES)
+    parser.add_argument("--slack-token", type=argparse.FileType(), help="Path to file containing a slack token (activates Slack bot feature).")
+    parser.add_argument("--free-mobile-user", type=str, help="User to be used with the Free Mobile SMS API")
+    parser.add_argument("--free-mobile-pass", type=str, help="Password used for the Free Mobile SMS API")
+    parser.add_argument("--location", type=float, metavar=("LAT", "LONG"), nargs=2, help="Latitude and longitude of your location. Default: St. Genis.", default=ST_GENIS)
+    parser.add_argument("--max-distance", type=int, help="Maximum radius of search from your position in km. Default: " + str(MAX_DISTANCE) + " km" , default=MAX_DISTANCE)
+    parser.add_argument("--vaccines", type=str, nargs="*", help="List of vaccines to look for. P=Pfizer-BioNTech;  M=Moderna; AZ=AstraZeneca; J=Janssen. Default: all.", default=SELECTED_VACCINES)
+    parser.add_argument("--depts", type=str, nargs="*", help="List of department numbers where to look for vaccines (add 0 before single-digit depts. e.g. 01 not 1). Default: 01 (Ain) + neighbouring depts.", default=DEPARTMENTS)
 
-parser = argparse.ArgumentParser(description="A bot that automatically fetches date from ViteMaDose and finds appointments within 24h.")
-parser.add_argument("--interval", type=int, help="Time in minutes between queries to ViteMaDose. Default: " + str(PING_INTERVAL_MINUTES), default=PING_INTERVAL_MINUTES)
-parser.add_argument("--slack-token", type=argparse.FileType(), help="Path to file containing a slack token (activates Slack bot feature).")
-parser.add_argument("--location", type=float, metavar=("LAT", "LONG"), nargs=2, help="Latitude and longitude of your location. Default: St. Genis.", default=ST_GENIS)
-parser.add_argument("--max-distance", type=int, help="Maximum radius of search from your position in km. Default: " + str(MAX_DISTANCE) + " km" , default=MAX_DISTANCE)
-parser.add_argument("--vaccines", type=str, nargs="*", help="List of vaccines to look for. P=Pfizer-BioNTech;  M=Moderna; AZ=AstraZeneca; J=Janssen. Default: all.", default=SELECTED_VACCINES)
-parser.add_argument("--depts", type=str, nargs="*", help="List of department numbers where to look for vaccines (add 0 before single-digit depts. e.g. 01 not 1). Default: 01 (Ain) + neighbouring depts.", default=DEPARTMENTS)
+    args = parser.parse_args()
 
-args = parser.parse_args()
+    # For free mobile, both user and pass are required
+    if bool(args.free_mobile_user) != bool(args.free_mobile_pass):  # XOR
+        print('Both user and pass are required to use the free mobile API')
+        exit()
+
+    return args
+
+
+args = get_args()
 
 PING_INTERVAL_MINUTES = args.interval
 SLACK_TOKEN_FILE = args.slack_token
@@ -135,6 +147,18 @@ while(True):
           "```" + tabulate.tabulate(sorted_appointments, headers=table_header) + "```",
         "#vaccinbot"
       )
+
+  # Send an SMS if a combo of user/pass for the Free Mobile API are supplied
+  if args.free_mobile_user:
+      print("Sending SMS…")
+      base = "https://smsapi.free-mobile.fr/sendmsg"
+      msg = tabulate.tabulate(sorted_appointments, headers=table_header)
+      url = f"{base}?user={args.free_mobile_user}&pass={args.free_mobile_pass}&msg={msg}"
+      r = requests.post(url)
+
+      if r.status_code == 403:
+          print("Error while sending SMS: wrong credentials")
+
 
   print("Sleeping, back in", PING_INTERVAL_MINUTES, " minutes")
   time.sleep(60*PING_INTERVAL_MINUTES)


### PR DESCRIPTION
Each Free Mobile client has access to a free SMS API. The service is intended to be used for alerts, exactly what we're looking for here.

The pass can be found in "My Options" in your personnal account.

Example usage: 
 `python3.6 Vaccinbot.py --free_mobile_user user --free_mobile_pass pass`

Tested with my own credentials, works fine. Would maybe need to beautify the text but it's not that important.
